### PR TITLE
feat: recording destination chooser in grid view

### DIFF
--- a/scripts/widget_visualization/wv_grid_recording_controls.py
+++ b/scripts/widget_visualization/wv_grid_recording_controls.py
@@ -1,0 +1,374 @@
+"""Visual test for proposed GridView recording destination controls.
+
+Layout proposal:
+  - Destination row (above action row): [Extrinsic Calibration cb] [Recording name: input] <stretch> [dest summary] [Open Folder]
+  - Action row (existing): [Record] [Stop] <stretch> [duration] [Refresh: combo] [Mirror]
+  - Status row: alignment stats label
+
+The destination row shows WHERE recordings go. The action row shows WHAT to do.
+When "Extrinsic Calibration" is checked, the name input hides (destination is implicit).
+When unchecked, a QLineEdit appears with an auto-generated default name.
+
+States captured:
+  01: Default state -- extrinsic unchecked, recording name visible
+  02: Extrinsic checked -- name input hidden
+  03: Recording in progress -- destination controls disabled
+  04: Stopping -- everything disabled
+  05: Full window with 4 mock camera tiles
+  06: Controls-only close-up (custom recording)
+  07: Controls close-up with extrinsic checked
+
+Usage:
+    python scripts/widget_visualization/wv_grid_recording_controls.py
+    xvfb-run --auto-servernum python scripts/widget_visualization/wv_grid_recording_controls.py
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor, QFont, QPainter, QPixmap
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from utils import capture_widget, clear_output_dir, process_events_for
+
+
+class MockSourceTile(QFrame):
+    """Simplified stand-in for SourceTile -- just a colored rectangle."""
+
+    def __init__(self, source_id: int, label: str, color: QColor, parent=None):
+        super().__init__(parent)
+        self.setFrameStyle(QFrame.Shape.Box | QFrame.Shadow.Sunken)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(2)
+
+        frame_label = QLabel()
+        frame_label.setMinimumSize(280, 180)
+        frame_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        pixmap = QPixmap(280, 180)
+        pixmap.fill(color)
+        painter = QPainter(pixmap)
+        painter.setPen(Qt.GlobalColor.white)
+        font = painter.font()
+        font.setPointSize(20)
+        font.setBold(True)
+        painter.setFont(font)
+        painter.drawText(pixmap.rect(), Qt.AlignmentFlag.AlignCenter, f"cam_{source_id}")
+        painter.end()
+        frame_label.setPixmap(pixmap)
+        layout.addWidget(frame_label)
+
+        info_row = QHBoxLayout()
+        name_label = QLabel(label)
+        name_label.setStyleSheet("font-weight: bold;")
+        res_label = QLabel("1280x720")
+        res_label.setStyleSheet("color: #AAAAAA;")
+        ignore_cb = QCheckBox("Ignore")
+        info_row.addWidget(name_label)
+        info_row.addStretch()
+        info_row.addWidget(ignore_cb)
+        info_row.addWidget(res_label)
+        layout.addLayout(info_row)
+
+        stats_label = QLabel("29.8 fps | 2.1ms jitter")
+        stats_label.setStyleSheet("font-size: 10px; color: #888888;")
+        layout.addWidget(stats_label)
+
+        focus_btn = QPushButton("Focus")
+        layout.addWidget(focus_btn)
+
+
+class GridViewProposal(QWidget):
+    """Proposed GridView layout with recording destination controls."""
+
+    focus_requested = Signal(int)
+    record_requested = Signal()
+    stop_requested = Signal()
+    poll_interval_changed = Signal(int)
+    mirror_toggled = Signal(bool)
+    ignore_toggled = Signal(int, bool)
+
+    open_folder_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        main_layout = QVBoxLayout(self)
+
+        # Grid for source tiles
+        self._grid_widget = QWidget()
+        self._grid_layout = QGridLayout(self._grid_widget)
+        main_layout.addWidget(self._grid_widget, stretch=1)
+
+        # Separator
+        separator = QFrame()
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setFrameShadow(QFrame.Shadow.Sunken)
+        main_layout.addWidget(separator)
+
+        # Destination row (NEW)
+        dest_row = QHBoxLayout()
+        dest_row.setContentsMargins(0, 4, 0, 4)
+
+        self._extrinsic_cb = QCheckBox("Extrinsic Calibration")
+        self._extrinsic_cb.setToolTip(
+            "When checked, recordings are saved to calibration/extrinsic/.\n"
+            "When unchecked, recordings are saved to recordings/<name>/."
+        )
+        dest_row.addWidget(self._extrinsic_cb)
+        dest_row.addSpacing(12)
+
+        self._name_label = QLabel("Recording name:")
+        self._name_label.setStyleSheet("color: #AAAAAA;")
+        dest_row.addWidget(self._name_label)
+
+        self._name_input = QLineEdit("recording_001")
+        self._name_input.setMinimumWidth(160)
+        self._name_input.setMaximumWidth(240)
+        self._name_input.setPlaceholderText("e.g. trial_001")
+        dest_row.addWidget(self._name_input)
+
+        self._dest_summary = QLabel("")
+        self._dest_summary.setStyleSheet(
+            "color: #888888; font-style: italic; font-size: 11px;"
+        )
+        dest_row.addWidget(self._dest_summary)
+
+        dest_row.addStretch()
+
+        self._open_folder_btn = QPushButton("Open Folder")
+        self._open_folder_btn.setToolTip("Open project folder in file manager")
+        self._open_folder_btn.setFlat(True)
+        self._open_folder_btn.setStyleSheet(
+            "QPushButton { color: #0078d4; text-decoration: underline;"
+            "  padding: 4px 8px; }"
+            "QPushButton:hover { color: #106ebe; }"
+            "QPushButton:pressed { color: #005a9e; }"
+        )
+        dest_row.addWidget(self._open_folder_btn)
+
+        main_layout.addLayout(dest_row)
+
+        # Action row (existing controls)
+        action_row = QHBoxLayout()
+        action_row.setContentsMargins(0, 0, 0, 0)
+
+        self._record_btn = QPushButton("Record")
+        self._record_btn.setStyleSheet(
+            "QPushButton {"
+            "  background-color: #c0392b; color: white; border: none;"
+            "  border-radius: 4px; padding: 8px 20px; font-weight: bold;"
+            "}"
+            "QPushButton:hover { background-color: #e74c3c; }"
+            "QPushButton:pressed { background-color: #922b21; }"
+            "QPushButton:disabled { background-color: #555555; color: #888888; }"
+        )
+        self._stop_btn = QPushButton("Stop")
+        self._stop_btn.setEnabled(False)
+        self._stop_btn.setStyleSheet(
+            "QPushButton {"
+            "  background-color: #555555; color: white; border: none;"
+            "  border-radius: 4px; padding: 8px 20px; font-weight: bold;"
+            "}"
+            "QPushButton:hover { background-color: #666666; }"
+            "QPushButton:pressed { background-color: #444444; }"
+            "QPushButton:disabled { background-color: #333333; color: #666666; }"
+        )
+        self._duration_label = QLabel("00:00:00")
+
+        action_row.addWidget(self._record_btn)
+        action_row.addWidget(self._stop_btn)
+        action_row.addStretch()
+        action_row.addWidget(self._duration_label)
+        action_row.addSpacing(16)
+        action_row.addWidget(QLabel("Refresh:"))
+        self._fps_combo = QComboBox()
+        self._fps_combo.addItems(["15 fps", "30 fps", "60 fps"])
+        self._fps_combo.setCurrentText("30 fps")
+        action_row.addWidget(self._fps_combo)
+        action_row.addSpacing(16)
+        self._mirror_cb = QCheckBox("Mirror")
+        action_row.addWidget(self._mirror_cb)
+
+        main_layout.addLayout(action_row)
+
+        # Status bar
+        self._status_label = QLabel("Spread: 12.3ms | Complete: 98%")
+        self._status_label.setStyleSheet("color: #888888; font-size: 11px;")
+        main_layout.addWidget(self._status_label)
+
+        # Wire signals
+        self._extrinsic_cb.toggled.connect(self._on_extrinsic_toggled)
+        self._name_input.textChanged.connect(self._on_name_changed)
+        self._open_folder_btn.clicked.connect(self.open_folder_requested.emit)
+        self._record_btn.clicked.connect(self.record_requested.emit)
+        self._stop_btn.clicked.connect(self.stop_requested.emit)
+        self._mirror_cb.toggled.connect(self.mirror_toggled.emit)
+
+        self._update_dest_summary()
+
+    def _on_extrinsic_toggled(self, checked: bool) -> None:
+        self._name_label.setVisible(not checked)
+        self._name_input.setVisible(not checked)
+        self._update_dest_summary()
+
+    def _on_name_changed(self, text: str) -> None:
+        self._update_dest_summary()
+
+    def _update_dest_summary(self) -> None:
+        if self._extrinsic_cb.isChecked():
+            self._dest_summary.setText("-> calibration/extrinsic/")
+        else:
+            name = self._name_input.text() or "untitled"
+            self._dest_summary.setText(f"-> recordings/{name}/")
+
+    def set_recording_name(self, name: str) -> None:
+        self._name_input.blockSignals(True)
+        self._name_input.setText(name)
+        self._name_input.blockSignals(False)
+        self._update_dest_summary()
+
+    def set_destination_enabled(self, enabled: bool) -> None:
+        self._extrinsic_cb.setEnabled(enabled)
+        self._name_input.setEnabled(enabled)
+
+    def set_recording(self, is_recording: bool) -> None:
+        self._record_btn.setEnabled(not is_recording)
+        self._stop_btn.setEnabled(is_recording)
+        self._stop_btn.setText("Stop")
+        self.set_destination_enabled(not is_recording)
+        if not is_recording:
+            self._duration_label.setText("00:00:00")
+
+    def set_stopping(self) -> None:
+        self._record_btn.setEnabled(False)
+        self._stop_btn.setEnabled(False)
+        self._stop_btn.setText("Stopping...")
+        self.set_destination_enabled(False)
+
+    def add_mock_tile(self, source_id: int, label: str, color: QColor) -> None:
+        tile = MockSourceTile(source_id, label, color)
+        idx = self._grid_layout.count()
+        row, col = divmod(idx, 3)
+        self._grid_layout.addWidget(tile, row, col)
+
+
+def main() -> None:
+    clear_output_dir()
+    app = QApplication(sys.argv)
+
+    print("=" * 60)
+    print("GRID VIEW RECORDING DESTINATION CONTROLS")
+    print("=" * 60)
+
+    # Test 1: Default state
+    print("\n[1] Default state: extrinsic unchecked, recording name visible\n")
+    view = GridViewProposal()
+    view.add_mock_tile(0, "HD Pro Webcam C920", QColor(30, 80, 140))
+    view.add_mock_tile(1, "USB Camera", QColor(80, 30, 140))
+    view.add_mock_tile(2, "Logitech BRIO", QColor(30, 140, 80))
+    view.resize(1000, 700)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "01_default_custom_recording.png")
+    view.close()
+
+    # Test 2: Extrinsic checked
+    print("\n[2] Extrinsic calibration checked: name input hidden\n")
+    view = GridViewProposal()
+    view.add_mock_tile(0, "HD Pro Webcam C920", QColor(30, 80, 140))
+    view.add_mock_tile(1, "USB Camera", QColor(80, 30, 140))
+    view.add_mock_tile(2, "Logitech BRIO", QColor(30, 140, 80))
+    view._extrinsic_cb.setChecked(True)
+    view.resize(1000, 700)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "02_extrinsic_checked.png")
+    view.close()
+
+    # Test 3: Recording in progress
+    print("\n[3] Recording in progress: destination controls disabled\n")
+    view = GridViewProposal()
+    view.add_mock_tile(0, "HD Pro Webcam C920", QColor(30, 80, 140))
+    view.add_mock_tile(1, "USB Camera", QColor(80, 30, 140))
+    view.add_mock_tile(2, "Logitech BRIO", QColor(30, 140, 80))
+    view.set_recording(True)
+    view._duration_label.setText("00:01:23")
+    view.resize(1000, 700)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "03_recording_in_progress.png")
+    view.close()
+
+    # Test 4: Stopping
+    print("\n[4] Stopping state: all controls disabled\n")
+    view = GridViewProposal()
+    view.add_mock_tile(0, "HD Pro Webcam C920", QColor(30, 80, 140))
+    view.add_mock_tile(1, "USB Camera", QColor(80, 30, 140))
+    view.add_mock_tile(2, "Logitech BRIO", QColor(30, 140, 80))
+    view.set_stopping()
+    view.resize(1000, 700)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "04_stopping.png")
+    view.close()
+
+    # Test 5: 4 cameras, extrinsic
+    print("\n[5] Four cameras, extrinsic mode\n")
+    view = GridViewProposal()
+    view.add_mock_tile(0, "HD Pro Webcam C920", QColor(30, 80, 140))
+    view.add_mock_tile(1, "USB Camera", QColor(80, 30, 140))
+    view.add_mock_tile(2, "Logitech BRIO", QColor(30, 140, 80))
+    view.add_mock_tile(3, "Integrated Webcam", QColor(140, 80, 30))
+    view._extrinsic_cb.setChecked(True)
+    view.resize(1200, 800)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "05_four_cameras_extrinsic.png")
+    view.close()
+
+    # Test 6: Controls close-up
+    print("\n[6] Controls-only close-up\n")
+    view = GridViewProposal()
+    view.resize(900, 120)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "06_controls_closeup.png")
+    view.close()
+
+    # Test 7: Controls close-up extrinsic
+    print("\n[7] Controls close-up with extrinsic checked\n")
+    view = GridViewProposal()
+    view._extrinsic_cb.setChecked(True)
+    view.resize(900, 120)
+    view.show()
+    process_events_for(200)
+    capture_widget(view, "07_controls_closeup_extrinsic.png")
+    view.close()
+
+    print("\n" + "=" * 60)
+    print("VERIFICATION COMPLETE")
+    print("=" * 60)
+    print("\nScreenshots saved to: scripts/widget_visualization/output/")
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/recording_destinations.md
+++ b/specs/recording_destinations.md
@@ -1,0 +1,157 @@
+# Recording Destinations & Open Folder
+
+## Problem
+
+Grid view recordings always go to `recordings/`. Users need to choose between:
+- **Extrinsic calibration** recordings (`calibration/extrinsic/`)
+- **Named recordings** (`recordings/<name>/`)
+
+There's also no way to quickly open the project folder to inspect output files.
+
+## User Decisions (from interview)
+
+- Default recording name: auto-generate (e.g. `recording_001`), user can override
+- Existing destination with files: warn and confirm before overwriting
+- Destination controls: always visible, disabled during recording
+
+## Design
+
+### Recording Intent Dataclass
+
+New file: `src/multiwebcam/ui/recording_intent.py`
+
+```python
+@dataclass(frozen=True)
+class GridRecordingIntent:
+    is_extrinsic: bool
+    recording_name: str  # Only meaningful when is_extrinsic is False
+```
+
+The view constructs this from widget state and emits it with the record signal. The coordinator resolves it to a `Path`.
+
+### Default Name Generator
+
+New file: `src/multiwebcam/recording/naming.py`
+
+```python
+def next_recording_name(recordings_dir: Path) -> str:
+    """Return 'recording_NNN' where NNN is one past the highest existing."""
+```
+
+Pure function. Scans `recordings/` for existing `recording_NNN` folders. Returns `recording_001` if none exist. Must handle non-existent `recordings_dir` gracefully (return `recording_001`).
+
+### GridView Changes
+
+File: `src/multiwebcam/ui/views/grid_view.py`
+
+**New widgets** (destination row, inserted between grid and existing action row):
+
+```
+[Extrinsic Calibration checkbox] [Recording name: label+input] [-> path summary] ... [Open Folder link]
+```
+
+- Horizontal separator line between grid and destination row
+- When "Extrinsic Calibration" checked: name label+input hide, summary shows `-> calibration/extrinsic/`
+- When unchecked: name input visible with auto-generated default, summary shows `-> recordings/<name>/`
+- "Open Folder" styled as flat link button, right-aligned
+- All destination controls disabled during recording/stopping
+
+**Signal changes:**
+
+- `record_requested` changes from `Signal()` to `Signal(object)` — emits `GridRecordingIntent`
+- New: `open_folder_requested = Signal()`
+
+**New methods:**
+
+- `set_default_recording_name(name: str)` — sets the line edit text without triggering signals
+- `confirm_overwrite(display_name: str) -> bool` — shows `QMessageBox.question()`, returns True if user confirms
+
+**Updated methods:**
+
+- `set_recording(is_recording)` — also disables/enables extrinsic checkbox and name input
+- `set_stopping()` — also disables destination controls
+- Internal `_on_record_clicked()` — reads checkbox + line edit, constructs `GridRecordingIntent`, emits `record_requested(intent)`
+
+### Coordinator Changes
+
+File: `src/multiwebcam/ui/coordinator.py`
+
+**In `create_grid_view()`:**
+
+1. After creating view, call `view.set_default_recording_name(next_recording_name(recordings_dir))`
+2. Replace `_on_record()` closure:
+   ```python
+   def _on_record(intent: GridRecordingIntent):
+       if intent.is_extrinsic:
+           output_dir = self._project_path / "calibration" / "extrinsic"
+       else:
+           name = _sanitize_recording_name(intent.recording_name)
+           output_dir = self._project_path / "recordings" / name
+
+       # Overwrite check
+       if output_dir.exists() and any(output_dir.iterdir()):
+           if not view.confirm_overwrite(str(output_dir.relative_to(self._project_path))):
+               return
+
+       cam_ids = {
+           info.device_path: info.source_id
+           for info in self._sources.values()
+           if info.device_path and not info.error and not info.profile.ignore
+       }
+       if cam_ids:
+           p.start_recording(output_dir, cam_ids=cam_ids)
+   ```
+3. Connect `view.open_folder_requested` to handler:
+   ```python
+   def _on_open_folder():
+       from PySide6.QtCore import QUrl
+       from PySide6.QtGui import QDesktopServices
+       QDesktopServices.openUrl(QUrl.fromLocalFile(str(self._project_path)))
+   ```
+4. After `recording_stopped`, update default name:
+   ```python
+   def _on_recording_stopped():
+       view.set_recording(False)
+       recordings_dir = self._project_path / "recordings"
+       view.set_default_recording_name(next_recording_name(recordings_dir))
+   ```
+
+**Helper in coordinator:**
+
+```python
+import re
+
+def _sanitize_recording_name(raw: str) -> str:
+    """Sanitize user input to a safe filesystem name."""
+    name = raw.strip()
+    name = re.sub(r'[^\w\-]', '_', name)  # Only alphanumeric, underscore, hyphen
+    return name or "untitled"
+```
+
+### What Does NOT Change
+
+- **CapturePresenter** — `start_recording(output_dir, cam_ids)` interface already correct
+- **CaptureSession** — pure Python model, unchanged
+- **FrameRecorder** — receives output_dir, unchanged
+- **FocusView** — always records to `calibration/intrinsic/`, unchanged
+
+## File Summary
+
+| File | Action |
+|------|--------|
+| `src/multiwebcam/ui/recording_intent.py` | NEW — `GridRecordingIntent` frozen dataclass |
+| `src/multiwebcam/recording/naming.py` | NEW — `next_recording_name()` pure function |
+| `src/multiwebcam/ui/views/grid_view.py` | MODIFY — add destination row, change record signal |
+| `src/multiwebcam/ui/coordinator.py` | MODIFY — path resolution, overwrite check, open folder |
+
+## Verification
+
+1. Run widget visualization: `xvfb-run --auto-servernum python scripts/widget_visualization/wv_grid_recording_controls.py`
+2. Manual test with cameras:
+   - Record with default name -> files appear in `recordings/recording_001/`
+   - Record with custom name -> files appear in `recordings/<custom>/`
+   - Check "Extrinsic Calibration" and record -> files in `calibration/extrinsic/`
+   - Record to existing destination -> overwrite confirmation dialog appears
+   - Click "Open Folder" -> system file manager opens project directory
+   - Controls disabled during recording, re-enabled after stop
+   - Default name increments after each recording

--- a/src/multiwebcam/recording/naming.py
+++ b/src/multiwebcam/recording/naming.py
@@ -1,0 +1,33 @@
+"""Utilities for auto-generating recording names."""
+
+import re
+from pathlib import Path
+
+
+def next_recording_name(recordings_dir: Path) -> str:
+    """Return 'recording_NNN' where NNN is one past the highest existing.
+
+    Scans recordings_dir for folders matching the pattern 'recording_NNN'
+    and returns the next name in sequence. Returns 'recording_001' if no
+    matching folders exist or if the directory does not exist.
+
+    Args:
+        recordings_dir: Path to the recordings directory to scan.
+
+    Returns:
+        A string like 'recording_001', 'recording_002', etc.
+    """
+    if not recordings_dir.exists():
+        return "recording_001"
+
+    pattern = re.compile(r"^recording_(\d+)$")
+    highest = 0
+    for entry in recordings_dir.iterdir():
+        if entry.is_dir():
+            match = pattern.match(entry.name)
+            if match:
+                n = int(match.group(1))
+                if n > highest:
+                    highest = n
+
+    return f"recording_{highest + 1:03d}"

--- a/src/multiwebcam/ui/coordinator.py
+++ b/src/multiwebcam/ui/coordinator.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
 from PySide6.QtCore import QObject
+
+from multiwebcam.recording.naming import next_recording_name
+from multiwebcam.ui.recording_intent import GridRecordingIntent
 
 from multiwebcam.pipeline.session import CaptureSession
 from multiwebcam.profiles import ControlValue, ProfileRepository, SourceProfile
@@ -14,6 +18,14 @@ from multiwebcam.sources import FrameSource, FrameSourceConfig, FrameSourceOptio
 from multiwebcam.sources.controls import set_control
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_recording_name(raw: str) -> str:
+    """Sanitize user input to a safe filesystem name."""
+    name = raw.strip()
+    name = re.sub(r'[^\w\-]', '_', name)
+    name = name.lstrip('-')
+    return name or "untitled"
 
 
 @dataclass
@@ -184,6 +196,9 @@ class CaptureCoordinator(QObject):
                 w, h = info.profile.resolution
                 view.set_tile_resolution(source_id, f"{w}x{h}")
 
+        recordings_dir = self._project_path / "recordings"
+        view.set_default_recording_name(next_recording_name(recordings_dir))
+
         p = self._presenter
 
         # Wire presenter -> view
@@ -195,9 +210,13 @@ class CaptureCoordinator(QObject):
         self._connect(p.recording_duration, view.update_duration)
 
         rec_true = lambda: view.set_recording(True)
-        rec_false = lambda: view.set_recording(False)
+
+        def _on_recording_stopped():
+            view.set_recording(False)
+            view.set_default_recording_name(next_recording_name(recordings_dir))
+
         self._connect(p.recording_started, rec_true)
-        self._connect(p.recording_stopped, rec_false)
+        self._connect(p.recording_stopped, _on_recording_stopped)
 
         self._connect(view.ignore_toggled, self._on_ignore_toggled)
 
@@ -205,9 +224,18 @@ class CaptureCoordinator(QObject):
         self._connect(view.mirror_toggled, p.set_mirror)
 
         # Wire view -> presenter (view owns these, die with view)
-        output_dir = self._project_path / "recordings"
+        def _on_record(intent: GridRecordingIntent):
+            if intent.is_extrinsic:
+                output_dir = self._project_path / "calibration" / "extrinsic"
+            else:
+                name = _sanitize_recording_name(intent.recording_name)
+                output_dir = self._project_path / "recordings" / name
 
-        def _on_record():
+            if output_dir.exists() and any(output_dir.iterdir()):
+                relative = str(output_dir.relative_to(self._project_path))
+                if not view.confirm_overwrite(relative):
+                    return
+
             cam_ids = {
                 info.device_path: info.source_id
                 for info in self._sources.values()
@@ -219,6 +247,13 @@ class CaptureCoordinator(QObject):
         view.record_requested.connect(_on_record)
         view.stop_requested.connect(p.stop_recording)
         view.poll_interval_changed.connect(p.set_grid_poll_interval)
+
+        def _on_open_folder():
+            from PySide6.QtCore import QUrl
+            from PySide6.QtGui import QDesktopServices
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(self._project_path)))
+
+        view.open_folder_requested.connect(_on_open_folder)
 
         p.enter_grid_mode()
         self._pause_ignored_producers()

--- a/src/multiwebcam/ui/recording_intent.py
+++ b/src/multiwebcam/ui/recording_intent.py
@@ -1,0 +1,17 @@
+"""Recording intent dataclass for grid view recording decisions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GridRecordingIntent:
+    """Encapsulates user's recording destination choice from the grid view.
+
+    Attributes:
+        is_extrinsic: True if recording to calibration/extrinsic/, False for recordings/<name>/
+        recording_name: The user-supplied or auto-generated name. Only meaningful when
+            is_extrinsic is False.
+    """
+
+    is_extrinsic: bool
+    recording_name: str

--- a/src/multiwebcam/ui/views/grid_view.py
+++ b/src/multiwebcam/ui/views/grid_view.py
@@ -1,13 +1,16 @@
 """Grid view showing all sources simultaneously."""
 
 from PySide6.QtCore import Signal
-from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QPixmap, QRegularExpressionValidator
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QFrame,
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
+    QMessageBox,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -15,6 +18,7 @@ from PySide6.QtWidgets import (
 
 from multiwebcam.pipeline.alignment import AlignmentStats
 from multiwebcam.pipeline.report import CameraStats
+from multiwebcam.ui.recording_intent import GridRecordingIntent
 from multiwebcam.ui.views.source_tile import SourceTile
 
 
@@ -23,19 +27,21 @@ class GridView(QWidget):
 
     Signals:
         focus_requested(int): User wants to focus source with given source_id
-        record_requested: User clicked record button
+        record_requested(object): User clicked record button; emits GridRecordingIntent
         stop_requested: User clicked stop button
         poll_interval_changed(int): User changed poll interval (milliseconds)
         ignore_toggled(int, bool): User toggled ignore for a source (source_id, ignored)
         mirror_toggled(bool): User toggled horizontal flip
+        open_folder_requested: User clicked Open Folder button
     """
 
     focus_requested = Signal(int)  # source_id
-    record_requested = Signal()
+    record_requested = Signal(object)  # GridRecordingIntent
     stop_requested = Signal()
     poll_interval_changed = Signal(int)  # milliseconds
     mirror_toggled = Signal(bool)
     ignore_toggled = Signal(int, bool)  # source_id, ignored
+    open_folder_requested = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -50,6 +56,47 @@ class GridView(QWidget):
         self._grid_layout = QGridLayout(self._grid_widget)
         main_layout.addWidget(self._grid_widget, stretch=1)
 
+        # Horizontal separator between grid and controls
+        separator = QFrame()
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setFrameShadow(QFrame.Shadow.Sunken)
+        main_layout.addWidget(separator)
+
+        # Destination row (above action controls)
+        dest_row = QHBoxLayout()
+
+        self._extrinsic_cb = QCheckBox("Extrinsic Calibration")
+        dest_row.addWidget(self._extrinsic_cb)
+
+        dest_row.addSpacing(16)
+
+        self._name_label = QLabel("Recording name:")
+        self._name_label.setStyleSheet("color: gray;")
+        dest_row.addWidget(self._name_label)
+
+        self._name_input = QLineEdit("recording_001")
+        self._name_input.setMinimumWidth(160)
+        self._name_input.setMaximumWidth(240)
+        self._name_input.setValidator(
+            QRegularExpressionValidator(r"[\w\-]+", self._name_input)
+        )
+        dest_row.addWidget(self._name_input)
+
+        self._dest_summary = QLabel("")
+        self._dest_summary.setStyleSheet("color: gray; font-style: italic;")
+        dest_row.addWidget(self._dest_summary)
+
+        dest_row.addStretch()
+
+        self._open_folder_btn = QPushButton("Open Folder")
+        self._open_folder_btn.setFlat(True)
+        self._open_folder_btn.setStyleSheet(
+            "color: #4A9EFF; text-decoration: underline;"
+        )
+        dest_row.addWidget(self._open_folder_btn)
+
+        main_layout.addLayout(dest_row)
+
         # Recording controls
         controls = QHBoxLayout()
         self._record_btn = QPushButton("Record")
@@ -57,7 +104,7 @@ class GridView(QWidget):
         self._stop_btn.setEnabled(False)
         self._duration_label = QLabel("00:00:00")
 
-        self._record_btn.clicked.connect(self.record_requested.emit)
+        self._record_btn.clicked.connect(self._on_record_clicked)
         self._stop_btn.clicked.connect(self.stop_requested.emit)
 
         controls.addWidget(self._record_btn)
@@ -80,6 +127,13 @@ class GridView(QWidget):
         # Status bar
         self._status_label = QLabel("Ready")
         main_layout.addWidget(self._status_label)
+
+        # Wire destination controls
+        self._extrinsic_cb.toggled.connect(self._on_extrinsic_toggled)
+        self._name_input.textChanged.connect(self._update_dest_summary)
+        self._open_folder_btn.clicked.connect(self.open_folder_requested.emit)
+
+        self._update_dest_summary()
 
     def _on_fps_changed(self, text: str) -> None:
         fps = int(text.split()[0])
@@ -112,6 +166,46 @@ class GridView(QWidget):
         all_ignored = self._tiles and len(self._ignored_source_ids) >= len(self._tiles)
         self._record_btn.setEnabled(not all_ignored)
 
+    def _on_extrinsic_toggled(self, checked: bool) -> None:
+        """Hide/show name label and input based on extrinsic checkbox."""
+        self._name_label.setVisible(not checked)
+        self._name_input.setVisible(not checked)
+        self._update_dest_summary()
+
+    def _on_record_clicked(self) -> None:
+        """Construct GridRecordingIntent from widget state and emit record_requested."""
+        intent = GridRecordingIntent(
+            is_extrinsic=self._extrinsic_cb.isChecked(),
+            recording_name=self._name_input.text(),
+        )
+        self.record_requested.emit(intent)
+
+    def _update_dest_summary(self) -> None:
+        """Update the destination summary label based on current widget state."""
+        if self._extrinsic_cb.isChecked():
+            self._dest_summary.setText("-> calibration/extrinsic/")
+        else:
+            name = self._name_input.text() or "untitled"
+            self._dest_summary.setText(f"-> recordings/{name}/")
+
+    def set_default_recording_name(self, name: str) -> None:
+        """Set the recording name line edit text without triggering signals."""
+        self._name_input.blockSignals(True)
+        self._name_input.setText(name)
+        self._name_input.blockSignals(False)
+        self._update_dest_summary()
+
+    def confirm_overwrite(self, display_name: str) -> bool:
+        """Ask user to confirm overwriting an existing destination."""
+        result = QMessageBox.question(
+            self,
+            "Overwrite existing recording?",
+            f"'{display_name}' already contains files.\n\nOverwrite?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        return result == QMessageBox.StandardButton.Yes
+
     def display_frames(self, frames: dict[int, QPixmap]) -> None:
         """Update frames for multiple sources."""
         for source_id, pixmap in frames.items():
@@ -134,9 +228,15 @@ class GridView(QWidget):
 
     def set_recording(self, is_recording: bool) -> None:
         """Update UI for recording state."""
-        self._record_btn.setEnabled(not is_recording)
+        if not is_recording:
+            self._update_record_enabled()
+        else:
+            self._record_btn.setEnabled(False)
         self._stop_btn.setEnabled(is_recording)
         self._stop_btn.setText("Stop")
+        self._extrinsic_cb.setEnabled(not is_recording)
+        self._name_input.setEnabled(not is_recording)
+        self._open_folder_btn.setEnabled(not is_recording)
         for source_id, tile in self._tiles.items():
             tile.set_focus_enabled(
                 not is_recording, reason="Recording..." if is_recording else ""
@@ -153,6 +253,9 @@ class GridView(QWidget):
         self._record_btn.setEnabled(False)
         self._stop_btn.setEnabled(False)
         self._stop_btn.setText("Stopping...")
+        self._extrinsic_cb.setEnabled(False)
+        self._name_input.setEnabled(False)
+        self._open_folder_btn.setEnabled(False)
         for tile in self._tiles.values():
             tile.set_focus_enabled(False, reason="Stopping...")
             tile.set_ignore_enabled(False)


### PR DESCRIPTION
## Summary
- Users choose between **extrinsic calibration** (`calibration/extrinsic/`) and **named recordings** (`recordings/<name>/`) destinations
- Auto-incrementing default names (`recording_001`, `recording_002`, ...) with input sanitization
- Overwrite confirmation dialog when destination already contains files
- "Open Folder" button to launch file manager at project root
- All destination controls disabled during recording/draining

## Test plan
- [x] Run widget visualization: `python scripts/widget_visualization/wv_grid_recording_controls.py`
- [x] Launch `mwc`, verify default name shows `recording_001`
- [x] Toggle "Extrinsic Calibration" checkbox — name input hides, summary shows `-> calibration/extrinsic/`
- [x] Record with extrinsic checked — files land in `calibration/extrinsic/`
- [x] Record with custom name — files land in `recordings/<name>/`
- [x] Re-record to same destination — overwrite dialog appears
- [x] After recording, default name auto-increments
- [x] "Open Folder" opens file manager