### PR TITLE
refactor: rename frametimes.csv to timestamps.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Multi-camera capture and recording for USB webcams on Linux. Output feeds into [
 
 Captures video from multiple USB webcams simultaneously, recording to individual MP4 files with accurate timestamps. Each camera gets:
 - `cam_N.mp4` - H.264 encoded video
-- `cam_N_frametimes.csv` - Frame timestamps for temporal alignment
+- `timestamps.csv` - Combined frame timestamps for temporal alignment (all cameras)
 
 This is **not** hardware-synchronized capture. Consumer USB webcams have no genlock. We capture independently and record timestamps so Caliscope can align frames temporally (typical precision: 10-50ms).
 
@@ -63,9 +63,8 @@ your_project/
 ├── multiwebcam.toml      # Camera configuration
 └── recordings/
     ├── cam_0.mp4
-    ├── cam_0_frametimes.csv
     ├── cam_1.mp4
-    ├── cam_1_frametimes.csv
+    ├── timestamps.csv     # Combined timestamps for all cameras
     └── ...
 ```
 

--- a/src/multiwebcam/pipeline/session.py
+++ b/src/multiwebcam/pipeline/session.py
@@ -355,7 +355,7 @@ class CaptureSession:
         Begin recording all cameras to output_dir.
 
         Args:
-            output_dir: Directory for MP4 files and frametimes.csv
+            output_dir: Directory for MP4 files and timestamps.csv
             cam_ids: Optional mapping of device_path -> cam_id for filenames.
                     If None, auto-assigns based on device_id from path
                     (e.g., /dev/video0 -> 0, /dev/video2 -> 1)
@@ -422,7 +422,7 @@ class CaptureSession:
         The recording process:
         1. Clear is_recording flag (producers stop pushing)
         2. Send sentinel (None) to each recording queue
-        3. Recorder drains queues and finalizes MP4 + frametimes.csv
+        3. Recorder drains queues and finalizes MP4 + timestamps.csv
         """
         if not self._is_recording.is_set():
             logger.warning("Not recording, nothing to stop")

--- a/src/multiwebcam/recording/__init__.py
+++ b/src/multiwebcam/recording/__init__.py
@@ -1,11 +1,11 @@
 """Recording system for multi-camera capture."""
 
-from multiwebcam.recording.frametimes import FrametimesCollector, write_frametimes_csv
+from multiwebcam.recording.timestamps import TimestampCollector, write_timestamps_csv
 from multiwebcam.recording.recorder import FrameRecorder, RecordingResult
 
 __all__ = [
     "FrameRecorder",
     "RecordingResult",
-    "FrametimesCollector",
-    "write_frametimes_csv",
+    "TimestampCollector",
+    "write_timestamps_csv",
 ]

--- a/src/multiwebcam/recording/encoder.py
+++ b/src/multiwebcam/recording/encoder.py
@@ -24,7 +24,7 @@ class CameraEncoder:
     gets its own encoder thread that:
     1. Drains frames from the recording queue
     2. Encodes to MP4 via PyAV
-    3. Reports timestamps to FrametimesCollector
+    3. Reports timestamps to TimestampCollector
     4. Exits when sentinel (None) is received
 
     The encoder runs in its own daemon thread.

--- a/src/multiwebcam/recording/recorder.py
+++ b/src/multiwebcam/recording/recorder.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from queue import Queue
 
 from multiwebcam.recording.encoder import CameraEncoder
-from multiwebcam.recording.frametimes import FrametimesCollector
+from multiwebcam.recording.timestamps import TimestampCollector
 from multiwebcam.sources.frame_packet import FramePacket
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class RecordingResult:
     frames_per_camera: dict[int, int]  # cam_id -> frame count
     duration_seconds: float
     errors: list[str]  # Any non-fatal errors encountered
-    frametimes_path: Path  # Path to frametimes.csv
+    timestamps_path: Path  # Path to timestamps.csv
 
 
 class FrameRecorder:
@@ -71,7 +71,7 @@ class FrameRecorder:
 
         Args:
             recording_queues: Per-camera recording queues (device_path -> queue)
-            output_dir: Directory to write MP4 files and frametimes.csv
+            output_dir: Directory to write MP4 files and timestamps.csv
             cam_ids: Device path to integer cam_id mapping
             codec: Video codec (default "h264")
         """
@@ -81,7 +81,7 @@ class FrameRecorder:
         self.codec = codec
 
         self._encoders: list[CameraEncoder] = []
-        self._frametimes_collector = FrametimesCollector()
+        self._timestamp_collector = TimestampCollector()
         self._start_time: float | None = None
         self._running = False
 
@@ -129,7 +129,7 @@ class FrameRecorder:
                 queue=queue,
                 output_path=output_path,
                 codec=self.codec,
-                timestamp_callback=self._frametimes_collector.add_frametime,
+                timestamp_callback=self._timestamp_collector.add_timestamp,
             )
             self._encoders.append(encoder)
 
@@ -163,7 +163,7 @@ class FrameRecorder:
                 frames_per_camera={},
                 duration_seconds=0.0,
                 errors=["Recording was not active"],
-                frametimes_path=self.output_dir / "frametimes.csv",
+                timestamps_path=self.output_dir / "timestamps.csv",
             )
 
         logger.info("Stopping recording, draining encoder queues...")
@@ -187,12 +187,12 @@ class FrameRecorder:
             frames_per_camera[encoder.cam_id] = encoder.frames_written
             all_errors.extend(encoder.errors)
 
-        # Write frametimes.csv
-        frametimes_path = self.output_dir / "frametimes.csv"
+        # Write timestamps.csv
+        timestamps_path = self.output_dir / "timestamps.csv"
         try:
-            self._frametimes_collector.write_csv(frametimes_path)
+            self._timestamp_collector.write_csv(timestamps_path)
         except Exception as e:
-            error_msg = f"Failed to write frametimes.csv: {e}"
+            error_msg = f"Failed to write timestamps.csv: {e}"
             logger.error(error_msg, exc_info=True)
             all_errors.append(error_msg)
 
@@ -203,7 +203,7 @@ class FrameRecorder:
             frames_per_camera=frames_per_camera,
             duration_seconds=duration,
             errors=all_errors,
-            frametimes_path=frametimes_path,
+            timestamps_path=timestamps_path,
         )
 
         logger.info(

--- a/src/multiwebcam/recording/timestamps.py
+++ b/src/multiwebcam/recording/timestamps.py
@@ -1,4 +1,4 @@
-"""Frametimes collection and CSV writing for recordings."""
+"""Timestamp collection and CSV writing for recordings."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
-class FrametimeEntry:
+class TimestampEntry:
     """A single frame's timestamp metadata."""
 
     cam_id: int
@@ -21,7 +21,7 @@ class FrametimeEntry:
     frame_time: float
 
 
-class FrametimesCollector:
+class TimestampCollector:
     """
     Thread-safe collector for frame timestamps during recording.
 
@@ -29,21 +29,21 @@ class FrametimesCollector:
     stops, the collector writes all timestamps to CSV in a single atomic operation.
 
     Usage:
-        collector = FrametimesCollector()
+        collector = TimestampCollector()
 
         # From encoder threads
-        collector.add_frametime(cam_id=0, frame_index=0, frame_time=1234.567)
-        collector.add_frametime(cam_id=1, frame_index=0, frame_time=1234.568)
+        collector.add_timestamp(cam_id=0, frame_index=0, frame_time=1234.567)
+        collector.add_timestamp(cam_id=1, frame_index=0, frame_time=1234.568)
 
         # On recording stop
-        collector.write_csv(output_dir / "frametimes.csv")
+        collector.write_csv(output_dir / "timestamps.csv")
     """
 
     def __init__(self) -> None:
-        self._entries: list[FrametimeEntry] = []
+        self._entries: list[TimestampEntry] = []
         self._lock = Lock()
 
-    def add_frametime(
+    def add_timestamp(
         self,
         cam_id: int,
         frame_index: int,
@@ -59,7 +59,7 @@ class FrametimesCollector:
             frame_index: Per-camera sequential frame index
             frame_time: Timestamp in seconds
         """
-        entry = FrametimeEntry(
+        entry = TimestampEntry(
             cam_id=cam_id,
             frame_index=frame_index,
             frame_time=frame_time,
@@ -80,28 +80,28 @@ class FrametimesCollector:
         Sorts entries by (cam_id, frame_index) before writing.
 
         Args:
-            output_path: Path to write frametimes.csv
+            output_path: Path to write timestamps.csv
         """
         with self._lock:
             # Sort by cam_id, then frame index for deterministic output
             sorted_entries = sorted(self._entries, key=lambda e: (e.cam_id, e.frame_index))
 
-        write_frametimes_csv(sorted_entries, output_path)
-        logger.info(f"Wrote {len(sorted_entries)} frametimes to {output_path}")
+        write_timestamps_csv(sorted_entries, output_path)
+        logger.info(f"Wrote {len(sorted_entries)} timestamps to {output_path}")
 
     @property
     def frame_count(self) -> int:
-        """Total number of frametimes collected."""
+        """Total number of timestamps collected."""
         with self._lock:
             return len(self._entries)
 
 
-def write_frametimes_csv(entries: list[FrametimeEntry], output_path: Path) -> None:
+def write_timestamps_csv(entries: list[TimestampEntry], output_path: Path) -> None:
     """
-    Write frametime entries to CSV file.
+    Write timestamp entries to CSV file.
 
     Args:
-        entries: List of FrametimeEntry to write
+        entries: List of TimestampEntry to write
         output_path: Path to output CSV file
     """
     with open(output_path, "w", newline="") as f:


### PR DESCRIPTION
## Summary
- Renames output file from `frametimes.csv` to `timestamps.csv` to match what Caliscope expects as input
- Renames `FrametimesCollector` → `TimestampCollector`, `FrametimeEntry` → `TimestampEntry`, and related symbols
- Updates README, session.py docstrings, and encoder docstring references

## Test plan
- [ ] Run a recording and verify `timestamps.csv` is produced (not `frametimes.csv`)
- [ ] Verify Caliscope reads the output directory without errors